### PR TITLE
Changes to interceptor engagement

### DIFF
--- a/GCICAP.lua
+++ b/GCICAP.lua
@@ -868,6 +868,15 @@ do
                   gcicap.log:info("Airfield closer to intruder than flight or no flight available. Spawning GCI")
                   local gci = gcicap.spawnGCI(side, intruder)
                 end
+              else
+                if (not gcicap[side].limit_resources
+                    or (gcicap[side].limit_resources and gcicap[side].supply > 0))
+                  and #gcicap[side].gci.flights < gcicap[side].gci.groups_count
+                  and gcicap[side].gci.enabled then
+                  -- spawn CGI
+                  gcicap.log:info("No CAP flights or already airborne GCI. Spawning GCI")
+                  local gci = gcicap.spawnGCI(side, intruder)
+                end
               end
             end
           end

--- a/GCICAP.lua
+++ b/GCICAP.lua
@@ -384,7 +384,7 @@ do
       local side = gcicap.coalitionToSide(group:getCoalition())
       local f = {}
       f.side = side
-      f.giveUp = false
+      f.give_up = false
       f.group = group
       f.group_name = group:getName()
       f.airbase = airbase
@@ -500,7 +500,7 @@ do
 
     -- check if interceptor even still exists
     if self.group:isExist() then
-      if target:isExist() and target:inAir() and self.giveUp ~= true then
+      if target:isExist() and target:inAir() and self.give_up ~= true then
         local target_pos = target:getPoint()
         local ctl = self.group:getController()
 
@@ -528,7 +528,7 @@ do
                           command = "local group = ...\
                           local flight = gcicap.Flight.getFlight(group)\
                           if flight then\
-                            flight.giveUp = true\
+                            flight.give_up = true\
                             if flight.zone then\
                               if flight.intercepting then\
                                 flight:taskWithCAP()\
@@ -562,7 +562,7 @@ do
           -- if there's still an EWR detecting or we are responding to the initial call
           -- then set the target position. do not allow revectoring if no EWR is detecting us now
           if (Unit.isExist(intruder.detected_by) and intruder.detected_by:isActive()) then
-            self.giveUp = false
+            self.give_up = false
             self.intercept_point = mist.utils.deepCopy(target_pos)
             ctl:setTask(gci_task)
             gcicap.log:info("Vectoring $1 to $2 ($3)", self.group:getName(),

--- a/GCICAP.lua
+++ b/GCICAP.lua
@@ -517,6 +517,32 @@ do
                   action = "Turning Point",
                   type = "Turning Point",
                   task = {
+                    id = "ComboTask",
+                    params = {
+                      tasks = {
+                        [1] = {
+                          number = 1,
+                          key = "CAP",
+                          id = "EngageTargets",
+                          enabled = true,
+                          auto = true,
+                          params = {
+                            targetTypes = { [1] = "Air" },
+                            priority = 0
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                [2] = {
+                  alt = target_pos.y,
+                  x = target_pos.x,
+                  y = target_pos.z,
+                  speed = gcicap.gci.speed,
+                  action = "Turning Point",
+                  type = "Turning Point",
+                  task = {
                     -- i don't really like this WrappedAction but it's needed in
                     -- the case the CGI completes this waypoint because of lack/loss
                     -- of target

--- a/GCICAP.lua
+++ b/GCICAP.lua
@@ -856,6 +856,7 @@ do
                 af_distance = af_distance + 15000 -- add 15km
                 if closest.distance < af_distance or af_distance == -1 then
                   -- task flight with intercept
+                  closest.flight.give_up = false
                   closest.flight:vectorToTarget(intruder)
                   return
                 end

--- a/GCICAP.lua
+++ b/GCICAP.lua
@@ -972,6 +972,7 @@ do
     local active_ewr = gcicap[side].active_ewr
     local intruder_count = 0
     local intruder_side = ""
+    local toremove = {}
     if side == "red" then
       -- set the side of the intruder
       intruder_side = "blue"
@@ -1103,15 +1104,21 @@ do
                   break
                 end
               end
-              if in_list then
-                table.remove(gcicap[side].intruders,intruder_num)
-                gcicap.log:info("Aircraft "..ac:getName().." no longer intruding")
-              end
+              if in_list then toremove[#toremove + 1] = intruder_num end
             end -- if ac_detected
           end -- if ac_group is existing
         end -- if ac ~= nil
       end -- for #active_ac
     end -- if active_ac > 0 and active_ewr > 0
+
+    -- we need to remove intruders from outside the loop
+    if #toremove > 0 then
+      for i = 1,#toremove do
+        intruder_count = intruder_count - 1
+        gcicap.log:info("Aircraft "..gcicap[side].intruders[i].name.." no longer intruding")
+        table.remove(gcicap[side].intruders,i)
+      end
+    end
     if intruder_count > 0 then
       return true
     else


### PR DESCRIPTION
I don't know if you're taking PRs but I thought I'd open one with the changes I made. Solves the weird acrobatics I mentioned in the forum thread and avoids the all-knowing engageGroup task type.

Reduces the knowledge of the intercepting group
- Only revector if the target has a large detected change in position
- Do not use engageGroup task since it knows where the group is
- Remove intruders from the list if they are no longer intruding
- Allow interceptors to give up
